### PR TITLE
fix/revert removal of `join` from scope of paths.py

### DIFF
--- a/nnunet/paths.py
+++ b/nnunet/paths.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 
 import os
+from os.path import join
 
 # do not modify these unless you know what you are doing
 my_output_identifier = "nnUNet"


### PR DESCRIPTION
various files get `join` via 
```
from nnunet.paths import *
```

your pull request removed join from paths.py, which breaks e.g. experiment_planner_baseline_2DUNet.py